### PR TITLE
Added messageUpdate for counting

### DIFF
--- a/handlers/_base.ts
+++ b/handlers/_base.ts
@@ -21,4 +21,5 @@ export abstract class BaseHandler {
   async onJoin(member: GuildMember): Promise<boolean> { return false }
   async onLeave(member: GuildMember): Promise<boolean> { return false }
   async onMessage(message: Message, extras: OnMessageExtras): Promise<boolean> { return false }
+  async onMessageUpdate(oldMessage: Message, newMessage: Message): Promise<boolean> { return false}
 }

--- a/handlers/counting.ts
+++ b/handlers/counting.ts
@@ -20,4 +20,19 @@ export class CountingHandler extends BaseHandler {
 
     return true
   }
+
+  async onMessageUpdate(message: Message, newMessage: Message) {
+    if (message.channel !== this.loaded.channels.counting) return false
+    const last = await (await message.channel.fetchMessages({ limit: 1 })).last()
+
+    // Short circuits if the message updated isn't the latest message
+    if(message.id !== last.id) return false
+    
+    const parsedOld = betterParseInt(message.content)
+    const parsedNew = betterParseInt(newMessage.content)
+
+    if(parsedNew !== parsedOld) await message.delete() 
+
+    return true
+  }
 }

--- a/index.ts
+++ b/index.ts
@@ -70,4 +70,10 @@ client.on('message', async (message: Message) => {
   await allHandlers(async (handler) => await handler.onMessage(message, { members, users }), 'onMessage')
 })
 
+client.on('messageUpdate', async (oldMessage: Message, newMessage: Message) => {
+  if (!loaded.done) return
+
+  await allHandlers(async (handler) => await handler.onMessageUpdate(oldMessage, newMessage), 'onMessageUpdate')
+})
+
 client.login(process.env.BOT_TOKEN)


### PR DESCRIPTION
I added an `onMessageUpdate` function to the base handler class, and implemented a way to delete updated messages for the counting handler, following this order:
- Checks if the message is the latest message (if it isn't, it's ignored)
- Checks that the parsed number in the message has changed (if not, it's ignored)
- Deletes the message if the previous checks were true

A few lines in particular are a little long, especially the `allHandlers` call in the `client.on('messageUpdate')` segment. This might be fine, or I could fix it, but I'm fine with either way